### PR TITLE
Bug: Update command accepts extra commas

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -56,7 +56,7 @@ public class ParserUtil {
         }
 
         // Split strictly by comma
-        String[] splitIndices = trimmedIndices.split(",");
+        String[] splitIndices = trimmedIndices.split(",", -1);
         List<Index> indices = new ArrayList<>();
 
         for (String indexString : splitIndices) {

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -307,5 +307,7 @@ public class ParserUtilTest {
 
         // FIX FOR COVERAGE: Leading comma causing an empty string at the start
         assertThrows(ParseException.class, () -> ParserUtil.parseIndices(",2"));
+
+        assertThrows(ParseException.class, () -> ParserUtil.parseIndices("1,2,3,,,"));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/UpdateCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UpdateCommandParserTest.java
@@ -229,4 +229,13 @@ public class UpdateCommandParserTest {
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }
+
+    @Test
+    public void parse_trailingCommas_failure() {
+        // The expected error message shown in your GUI screenshot
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, SingleUpdateCommand.MESSAGE_USAGE);
+
+        // Tests the parser with trailing commas and a valid prefix
+        assertParseFailure(parser, "1,2,3,,," + PHONE_DESC_AMY, expectedMessage);
+    }
 }


### PR DESCRIPTION
Closes #151 

Fixed bug where trailing commas were ignored by updating ParserUtil to use split(",", -1). This forces Java to retain empty strings, correctly triggering an invalid format error for inputs like 1,2,,,. Tests added to cover this edge case.