### PR TITLE
Remove legacy and enforce prefix for `find` command

### DIFF
--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -83,28 +83,8 @@ public class FindCommandParser implements Parser<FindCommand> {
         boolean hasAnySearchField = hasName || hasIc || hasPhone || hasEmail || hasDoctor;
         String preamble = argMultimap.getPreamble().trim();
 
-        // Handle legacy format: if no recognized prefixes, treat preamble as legacy patient name
         if (!hasAnySearchField) {
-            if (preamble.isEmpty()) {
-                throw new ParseException(MESSAGE_REQUIRES_PREFIX);
-            }
-            // Check if preamble contains valid patient names
-            List<String> nameKeywords = Arrays.asList(preamble.split("\\s+"));
-            boolean allValid = true;
-            for (String keyword : nameKeywords) {
-                if (!Name.isValidName(keyword)) {
-                    allValid = false;
-                    break;
-                }
-            }
-
-            // If all keywords are valid, it's valid legacy format but requires prefix
-            if (allValid) {
-                throw new ParseException(MESSAGE_REQUIRES_PREFIX);
-            }
-
-            // If any keyword is invalid, throw NAME validation error
-            throw new ParseException(Name.MESSAGE_CONSTRAINTS);
+            throw new ParseException(MESSAGE_REQUIRES_PREFIX);
         }
 
         if (!preamble.isEmpty()) {

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -54,12 +54,13 @@ public class FindCommandParserTest {
 
     @Test
     public void parse_unprefixedName_throwsParseException() {
-        assertParseFailure(parser, "Alice Bob",
-                "Find requires at least one search prefix. Only pn/, ic/, p/, e/, and d/ are allowed.\n"
-                        + FindCommand.MESSAGE_USAGE);
-        assertParseFailure(parser, " \n Alice \n \t Bob  \t",
-                "Find requires at least one search prefix. Only pn/, ic/, p/, e/, and d/ are allowed.\n"
-                        + FindCommand.MESSAGE_USAGE);
+        String requiresPrefix = "Find requires at least one search prefix. Only pn/, ic/, p/, e/, and d/ are allowed.\n"
+                + FindCommand.MESSAGE_USAGE;
+        assertParseFailure(parser, "Alice Bob", requiresPrefix);
+        assertParseFailure(parser, " \n Alice \n \t Bob  \t", requiresPrefix);
+        assertParseFailure(parser, "@", requiresPrefix);
+        assertParseFailure(parser, "John123", requiresPrefix);
+        assertParseFailure(parser, "Alice @Bob", requiresPrefix);
     }
 
     @Test
@@ -132,13 +133,6 @@ public class FindCommandParserTest {
         assertParseFailure(parser, " pn/John123", Name.MESSAGE_CONSTRAINTS);
         assertParseFailure(parser, " pn/Alice@Bob", Name.MESSAGE_CONSTRAINTS);
         assertParseFailure(parser, " pn/@", Name.MESSAGE_CONSTRAINTS);
-    }
-
-    @Test
-    public void parse_invalidLegacyPatientName_throwsParseException() {
-        assertParseFailure(parser, "@", Name.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, "John123", Name.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, "Alice @Bob", Name.MESSAGE_CONSTRAINTS);
     }
 
     @Test


### PR DESCRIPTION
Closes: #282 