### PR TITLE
fix(undo): reject extra arguments for consistency with exit command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -14,6 +14,8 @@ public class UndoCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "Undo successful: reversed the previous command.";
     public static final String MESSAGE_FAILURE = "Cannot undo: no recent action to undo, or undo was already used.";
+    public static final String MESSAGE_USAGE = "Usage: undo";
+    public static final String MESSAGE_EXTRA_PARAMETERS = "There should not be extra parameters.\nUsage: undo";
 
     private Command lastCommand;
 
@@ -40,5 +42,10 @@ public class UndoCommand extends Command {
     @Override
     public String toString() {
         return COMMAND_WORD;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this || other instanceof UndoCommand;
     }
 }

--- a/src/main/java/seedu/address/logic/parser/UndoCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UndoCommandParser.java
@@ -1,22 +1,28 @@
 package seedu.address.logic.parser;
 
 import seedu.address.logic.commands.UndoCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
- * Parses input arguments and creates a new UndoCommand object.
+ * Parses input arguments and creates a new {@code UndoCommand} object.
+ * <p>
+ * The undo command does not accept any parameters. If any additional
+ * arguments are provided, a {@link ParseException} will be thrown.
  */
 public class UndoCommandParser implements Parser<UndoCommand> {
 
     /**
-     * Parses the given {@code String} of arguments in the context of the UndoCommand
-     * and returns an UndoCommand object for execution.
-     * UndoCommand takes no arguments.
+     * Parses the given {@code String} of arguments and returns an {@code UndoCommand}.
      *
-     * @param args irrelevant (should be empty)
-     * @return a new UndoCommand
+     * @param args The input arguments provided by the user after the command word.
+     * @return An {@code UndoCommand} object.
+     * @throws ParseException If additional parameters are detected.
      */
     @Override
-    public UndoCommand parse(String args) {
+    public UndoCommand parse(String args) throws ParseException {
+        if (!args.trim().isEmpty()) {
+            throw new ParseException(UndoCommand.MESSAGE_EXTRA_PARAMETERS);
+        }
         return new UndoCommand();
     }
 }

--- a/src/test/java/seedu/address/logic/commands/UndoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UndoCommandTest.java
@@ -1,6 +1,8 @@
 package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
@@ -113,6 +115,15 @@ public class UndoCommandTest {
     public void toString_returnsCommandWord() {
         UndoCommand undoCommand = new UndoCommand();
         assertEquals(UndoCommand.COMMAND_WORD, undoCommand.toString());
+    }
+
+    @Test
+    public void equals() {
+        UndoCommand undoCommand1 = new UndoCommand();
+        UndoCommand undoCommand2 = new UndoCommand();
+        assertTrue(undoCommand1.equals(undoCommand1));
+        assertTrue(undoCommand1.equals(undoCommand2));
+        assertFalse(undoCommand1.equals("undo"));
     }
 
     /**

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -105,7 +105,12 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_undo() throws Exception {
         assertTrue(parser.parseCommand(UndoCommand.COMMAND_WORD) instanceof UndoCommand);
-        assertTrue(parser.parseCommand(UndoCommand.COMMAND_WORD + " anything") instanceof UndoCommand);
+    }
+
+    @Test
+    public void parseCommand_undoWithArguments_failure() {
+        assertThrows(ParseException.class, UndoCommand.MESSAGE_EXTRA_PARAMETERS, () ->
+                parser.parseCommand(UndoCommand.COMMAND_WORD + " anything"));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/UndoCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UndoCommandParserTest.java
@@ -1,5 +1,8 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.UndoCommand;
@@ -13,20 +16,17 @@ public class UndoCommandParserTest {
 
     @Test
     public void parse_noArguments_success() {
-        UndoCommand command = parser.parse("");
-        assert command != null;
+        assertParseSuccess(parser, "", new UndoCommand());
     }
 
     @Test
     public void parse_emptyString_success() {
-        UndoCommand command = parser.parse("   ");
-        assert command != null;
+        assertParseSuccess(parser, "   ", new UndoCommand());
     }
 
     @Test
-    public void parse_anyArguments_success() {
-        // UndoCommand ignores any arguments passed and returns a valid UndoCommand
-        UndoCommand command = parser.parse("some random text");
-        assert command != null;
+    public void parse_withArguments_throwsParseException() {
+        // UndoCommand should not accept any arguments
+        assertParseFailure(parser, "some random text", UndoCommand.MESSAGE_EXTRA_PARAMETERS);
     }
 }


### PR DESCRIPTION
- Add argument validation to UndoCommandParser to reject any extra parameters
  - Add MESSAGE_EXTRA_PARAMETERS constant to UndoCommand
  - Add equals() method to UndoCommand for test support
  - Update UndoCommandParserTest to verify rejection of extra arguments
  - Update AddressBookParserTest to validate new behavior
  - Now throws ParseException with helpful error message when arguments provided

    Fixes inconsistency where 'undo <text>' executed successfully despite UserGuide specifying only 'undo' alone as valid. ExitCommand already validates this correctly and undo should behave consistently.